### PR TITLE
fix: Bump log4j-api 2.25.3 -> 2.25.5 to remediate CVE-2026-49844

### DIFF
--- a/trino/pom.xml
+++ b/trino/pom.xml
@@ -2030,7 +2030,7 @@
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
-                <version>2.25.3</version>
+                <version>2.25.5</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Summary

Bumps `org.apache.logging.log4j:log4j-api` from 2.25.3 to 2.25.5 in `trino/pom.xml` to remediate [CVE-2026-49844](https://www.mend.io/vulnerability-database/CVE-2026-49844) (Medium, CVSS 5.8).

## Vulnerability

CVE-2026-49844 — Improper encoding of non-finite floating-point values during `MapMessage` JSON serialization in Apache Log4j API. RFC 8259 does not permit bare `NaN` / `Infinity` / `-Infinity` tokens, so a conformant JSON parser rejects the resulting document.

- **Affected:** `log4j-api` 2.13.1 through 2.25.4 and 2.26.0
- **Fixed in:** 2.25.5, 2.26.1
- **Reachability:** Only when the application logs a `MapMessage` containing an attacker-controlled non-finite float, via `JsonTemplateLayout` or any layout relying on `MapMessage.asJson()` / `MapMessage.getFormattedMessage({"JSON"})`.
- **Impact:** Integrity (Low). Scope: Changed.

## How the vulnerable version reached the repo

`trino/pom.xml` pins `org.apache.logging.log4j:log4j-api` at `2.25.3` in `dependencyManagement` (line 2033). The vulnerable jar is pulled transitively into `trino/lib/trino-filesystem-cache-alluxio` via:

```
trino-base-jdbc -> bootstrap -> log-manager -> log4j-to-slf4j 2.25.3 -> log4j-api 2.25.3
```

## Fix

Single line change in `trino/pom.xml`:

```diff
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
-                <version>2.25.3</version>
+                <version>2.25.5</version>
             </dependency>
```

Picked **2.25.5** (minimum patch) over 2.26.1 to keep the change minimal — 2.26.1 is the next minor line and is not required to remediate this CVE.

## Verification

After merge, re-running the Mend scan should report zero findings for CVE-2026-49844 because the dependencyManagement pin forces all transitive resolvers to pick up 2.25.5 (which is not in the vulnerable range 2.13.1–2.25.4).

Closes #231

## References

- https://logging.apache.org/security.html#CVE-2026-49844
- https://www.mend.io/vulnerability-database/CVE-2026-49844

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Log4j API dependency to version 2.25.5 for improved maintenance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->